### PR TITLE
Revert "build(deps): bump python from 3.12-slim to 3.13-slim in the deps group"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.12-slim
 
 RUN pip install --upgrade pip
 COPY requirements.txt .


### PR DESCRIPTION
Have to wait for pyarrow 18 before using python 3.13